### PR TITLE
feat(artifact-hub) add metadata file

### DIFF
--- a/artifacthub-repo.yaml
+++ b/artifacthub-repo.yaml
@@ -1,0 +1,6 @@
+repositoryID: 710fbc1e-ff7c-4940-a36f-b1eac95cb125
+owners:
+  - name: Nikolay Nikolaev
+    email: nikolay.nikolaev@konghq.com
+  - name: Austin Cawley-Edwards
+    email: austin.cawley@gmail.com


### PR DESCRIPTION
Allows us to claim [our repo on Artifact Hub](https://artifacthub.io/packages/helm/kuma/kuma), which is the replacement for Helm Hub.

This metadata file lists the same owners as currently in Helm Hub:
https://github.com/helm/hub/blob/2d965b985ac824284334fc00f18f3f0bfd87a545/repos.yaml#L1557-L1563

After this is merged and deployed, I'll make a request to claim the repo.

Closes https://github.com/kumahq/kuma/issues/1059