### PR TITLE
chore(helm): remove stale entries

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -927,31 +927,6 @@ entries:
     - https://github.com/kumahq/charts/releases/download/kuma-2.10.0/kuma-2.10.0.tgz
     version: 2.10.0
   - apiVersion: v2
-    appVersion: v2.9.13
-    created: "2026-03-24T06:47:25.538772177Z"
-    description: A Helm chart for the Kuma Control Plane
-    digest: 7db8addb5c63c46ef8d15fbaad0e3181045487f6e17bae51db8754fecf79055b
-    home: https://github.com/kumahq/kuma
-    icon: https://kuma.io/assets/images/brand/kuma-logo-new.svg
-    keywords:
-    - service mesh
-    - control plane
-    maintainers:
-    - email: jakub.dyszkiewicz@konghq.com
-      name: Jakub Dyszkiewicz
-      url: https://github.com/jakubdyszkiewicz
-    - email: charly.molter@konghq.com
-      name: Charly Molter
-      url: https://github.com/lahabana
-    - email: michael.beaumont@konghq.com
-      name: Mike Beaumont
-      url: https://github.com/michaelbeaumont
-    name: kuma
-    type: application
-    urls:
-    - https://github.com/kumahq/charts/releases/download/kuma-v2.9.13/kuma-v2.9.13.tgz
-    version: v2.9.13
-  - apiVersion: v2
     appVersion: 2.9.12
     created: "2026-02-25T18:42:04.659644388Z"
     description: A Helm chart for the Kuma Control Plane
@@ -1501,31 +1476,6 @@ entries:
     urls:
     - https://github.com/kumahq/charts/releases/download/kuma-2.8.0/kuma-2.8.0.tgz
     version: 2.8.0
-  - apiVersion: v2
-    appVersion: 2.7.23
-    created: "2026-03-23T16:14:28.847768896Z"
-    description: A Helm chart for the Kuma Control Plane
-    digest: fc5989772b6d0826cdf69055b1ca9d1b93b978888f3834c5422cd18bca0cb18f
-    home: https://github.com/kumahq/kuma
-    icon: https://kuma.io/assets/images/brand/kuma-logo-new.svg
-    keywords:
-    - service mesh
-    - control plane
-    maintainers:
-    - email: jakub.dyszkiewicz@konghq.com
-      name: Jakub Dyszkiewicz
-      url: https://github.com/jakubdyszkiewicz
-    - email: charly.molter@konghq.com
-      name: Charly Molter
-      url: https://github.com/lahabana
-    - email: michael.beaumont@konghq.com
-      name: Mike Beaumont
-      url: https://github.com/michaelbeaumont
-    name: kuma
-    type: application
-    urls:
-    - https://github.com/kumahq/charts/releases/download/kuma-2.7.23/kuma-2.7.23.tgz
-    version: 2.7.23
   - apiVersion: v2
     appVersion: 2.7.22
     created: "2026-02-21T14:53:34.999631735Z"


### PR DESCRIPTION
## Motivation

The release pipeline for kuma 2.7.23 and 2.9.13 fails at `helm/release` because stale chart entries already exist in the gh-pages index. These were published from builds using old commits before CVE fixes. The GitHub releases and tags have already been deleted but the index entries remain, causing "nothing to commit" errors.

## Implementation information

Remove 2.7.23 and v2.9.13 entries from index.yaml so the pipeline can republish clean charts.

Part of patch release Kong/team-mesh#600.