### PR TITLE
chore(helm): remove v2.9.13 entry

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -927,31 +927,6 @@ entries:
     - https://github.com/kumahq/charts/releases/download/kuma-2.10.0/kuma-2.10.0.tgz
     version: 2.10.0
   - apiVersion: v2
-    appVersion: v2.9.13
-    created: "2026-03-25T10:20:22.240097647Z"
-    description: A Helm chart for the Kuma Control Plane
-    digest: 2251fb0188fb14bbf6a60b8c383e313571f2099cc0cf0732bfa2684e68140f0e
-    home: https://github.com/kumahq/kuma
-    icon: https://kuma.io/assets/images/brand/kuma-logo-new.svg
-    keywords:
-    - service mesh
-    - control plane
-    maintainers:
-    - email: jakub.dyszkiewicz@konghq.com
-      name: Jakub Dyszkiewicz
-      url: https://github.com/jakubdyszkiewicz
-    - email: charly.molter@konghq.com
-      name: Charly Molter
-      url: https://github.com/lahabana
-    - email: michael.beaumont@konghq.com
-      name: Mike Beaumont
-      url: https://github.com/michaelbeaumont
-    name: kuma
-    type: application
-    urls:
-    - https://github.com/kumahq/charts/releases/download/kuma-v2.9.13/kuma-v2.9.13.tgz
-    version: v2.9.13
-  - apiVersion: v2
     appVersion: 2.9.12
     created: "2026-02-25T18:42:04.659644388Z"
     description: A Helm chart for the Kuma Control Plane


### PR DESCRIPTION
## Motivation

The v2.9.13 chart entry was published from the v-prefixed tag build. The 2.9.x line uses non-v-prefixed tags, so this entry needs to be removed so the correct `2.9.13` build can publish `kuma-2.9.13`.

## Implementation information

Remove v2.9.13 entry from index.yaml. The release and tag have already been deleted.